### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://mdoe.visualstudio.com/e30c5fb5-9564-4593-93fc-d196af69f34e/65077616-1abc-478a-9057-fc072c3abee3/_apis/work/boardbadge/0ee6ff3b-d09a-41f7-8d54-e0f139d1d68d)](https://mdoe.visualstudio.com/e30c5fb5-9564-4593-93fc-d196af69f34e/_boards/board/t/65077616-1abc-478a-9057-fc072c3abee3/Microsoft.RequirementCategory)
 # hello-world
 New World Repository
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#45456](https://mdoe.visualstudio.com/e30c5fb5-9564-4593-93fc-d196af69f34e/_workitems/edit/45456). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.